### PR TITLE
ar71xx: ethernet fixes

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
@@ -998,6 +998,7 @@ void __init ath79_register_eth(unsigned int id)
 			pdata->set_speed = ath79_set_speed_dummy;
 
 			pdata->switch_data = &ath79_switch_data;
+			pdata->use_flow_control = 1;
 
 			/* reset the built-in switch */
 			ath79_device_reset_set(AR934X_RESET_ETH_SWITCH);

--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
@@ -179,9 +179,11 @@ void __init ath79_register_mdio(unsigned int id, u32 phy_mask)
 	struct ag71xx_mdio_platform_data *mdio_data;
 	unsigned int max_id;
 
-	if (ath79_soc == ATH79_SOC_AR9341 ||
+	if (ath79_soc == ATH79_SOC_AR9331 ||
+	    ath79_soc == ATH79_SOC_AR9341 ||
 	    ath79_soc == ATH79_SOC_AR9342 ||
 	    ath79_soc == ATH79_SOC_AR9344 ||
+	    ath79_soc == ATH79_SOC_QCA9533 ||
 	    ath79_soc == ATH79_SOC_QCA9556 ||
 	    ath79_soc == ATH79_SOC_QCA9558 ||
 	    ath79_soc == ATH79_SOC_QCA956X)

--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
@@ -199,16 +199,16 @@ void __init ath79_register_mdio(unsigned int id, u32 phy_mask)
 	switch (ath79_soc) {
 	case ATH79_SOC_AR7241:
 	case ATH79_SOC_AR9330:
-	case ATH79_SOC_AR9331:
-	case ATH79_SOC_QCA9533:
 	case ATH79_SOC_TP9343:
 		mdio_dev = &ath79_mdio1_device;
 		mdio_data = &ath79_mdio1_data;
 		break;
 
+	case ATH79_SOC_AR9331:
 	case ATH79_SOC_AR9341:
 	case ATH79_SOC_AR9342:
 	case ATH79_SOC_AR9344:
+	case ATH79_SOC_QCA9533:
 	case ATH79_SOC_QCA9556:
 	case ATH79_SOC_QCA9558:
 	case ATH79_SOC_QCA956X:
@@ -246,7 +246,9 @@ void __init ath79_register_mdio(unsigned int id, u32 phy_mask)
 		mdio_data->is_ar9330 = 1;
 		/* fall through */
 	case ATH79_SOC_AR9331:
-		mdio_data->builtin_switch = 1;
+	case ATH79_SOC_QCA9533:
+		if (id == 1)
+			mdio_data->builtin_switch = 1;
 		break;
 
 	case ATH79_SOC_AR9341:
@@ -260,7 +262,6 @@ void __init ath79_register_mdio(unsigned int id, u32 phy_mask)
 		mdio_data->is_ar934x = 1;
 		break;
 
-	case ATH79_SOC_QCA9533:
 	case ATH79_SOC_TP9343:
 		mdio_data->builtin_switch = 1;
 		break;

--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
@@ -699,6 +699,7 @@ static int __init ath79_setup_phy_if_mode(unsigned int id,
 		case ATH79_SOC_AR7241:
 		case ATH79_SOC_AR9330:
 		case ATH79_SOC_AR9331:
+		case ATH79_SOC_QCA9533:
 		case ATH79_SOC_TP9343:
 			pdata->phy_if_mode = PHY_INTERFACE_MODE_GMII;
 			break;
@@ -709,7 +710,6 @@ static int __init ath79_setup_phy_if_mode(unsigned int id,
 		case ATH79_SOC_AR9341:
 		case ATH79_SOC_AR9342:
 		case ATH79_SOC_AR9344:
-		case ATH79_SOC_QCA9533:
 		case ATH79_SOC_QCA956X:
 			switch (pdata->phy_if_mode) {
 			case PHY_INTERFACE_MODE_MII:

--- a/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
+++ b/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
@@ -1251,7 +1251,7 @@ static struct ar7240sw *ar7240_probe(struct ag71xx *ag)
 		swdev->name = "AR7240/AR9330 built-in switch";
 		swdev->ports = AR7240_NUM_PORTS - 1;
 	} else if (sw_is_ar934x(as)) {
-		swdev->name = "AR934X built-in switch";
+		swdev->name = "AR934X/AR953X built-in switch";
 
 		if (pdata->phy_if_mode == PHY_INTERFACE_MODE_GMII) {
 			ar7240sw_reg_set(mii, AR934X_REG_OPER_MODE0,


### PR DESCRIPTION
Update MDIO settings for AR9331 and QCA9531/QCA9533, use GMII as a default mode on QCA9531/QCA9533 GMAC1 interface and enable flow control for it. Rename AR934X switch to AR934X/AR935X.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>