### PR TITLE
ar71xx: add back JFFS2 support

### DIFF
--- a/target/linux/ar71xx/generic/target.mk
+++ b/target/linux/ar71xx/generic/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=Generic
-FEATURES += squashfs
+FEATURES += jffs2 squashfs
 
 define Target/Description
 	Build firmware images for generic Atheros AR71xx/AR913x/AR934x based boards.


### PR DESCRIPTION
Enable image builds in JFFS2 format. Free-up some RAM with JFFS2 on 32MB devices.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>