### PR TITLE
ar71xx: correct LED state on tl-mr22u

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-mr22u.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-mr22u.c
@@ -44,7 +44,7 @@ static struct gpio_led tl_mr22u_leds_gpio[] __initdata = {
 	{
 		.name		= "tp-link:blue:system",
 		.gpio		= TL_MR22U_GPIO_LED_SYSTEM,
-		.active_low	= 1,
+		.active_low	= 0,
 	},
 };
 


### PR DESCRIPTION
system LED on MR22U is active high. other problems might be caused by LED subsystem bugs

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>